### PR TITLE
Update README now piccata supports Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 piccata - Python CoAp Toolkit
 =============================
 
-piccata is a simple CoAP (RFC7252) toolkit compatible with Python 2.7. 
+piccata is a simple CoAP (RFC7252) toolkit written in Python.
 
 The toolkit provides basic building blocks for using CoAP in an
 application. piccata handles messaging between endpoints 


### PR DESCRIPTION
As piccata now supports Python 3 generalise the statemeent
around Python and drop mentions of specific versions.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>